### PR TITLE
Add link to the blogpost in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Lepret
 
 Sample application to illustrate an end-to-end ES/CQRS example with EventStoreDB and Elixir.
+
+[See the detailed blogpost about the application here](https://kurtov.pro/blog/2024/06/an-end-to-end-es/cqrs-example-with-eventstoredb-and-phoenix/liveview/).


### PR DESCRIPTION
Thought it might make sense to link back to the blogpost in the README :-)

Feel free to close the PR and use different wording etc